### PR TITLE
Change nvcc and c flags to c++17 for posix systems on extensions/cuda/setup.py  

### DIFF
--- a/extensions/cuda/setup.py
+++ b/extensions/cuda/setup.py
@@ -5,7 +5,7 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 _src_path = os.path.dirname(os.path.abspath(__file__))
 
 nvcc_flags = [
-    '-O3', '-std=c++14',
+    '-O3', '-std=c++17',
     '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__',
 ]
 

--- a/extensions/cuda/setup.py
+++ b/extensions/cuda/setup.py
@@ -10,7 +10,7 @@ nvcc_flags = [
 ]
 
 if os.name == "posix":
-    c_flags = ['-O3', '-std=c++14']
+    c_flags = ['-O3', '-std=c++17']
 elif os.name == "nt":
     c_flags = ['/O2', '/std:c++17']
 

--- a/zipnerf_ns/zipnerf_datamanager.py
+++ b/zipnerf_ns/zipnerf_datamanager.py
@@ -70,3 +70,12 @@ class ZipNerfDataManager(VanillaDataManager):
         ray_indices = batch["indices"]
         ray_bundle = self.eval_ray_generator(ray_indices)
         return ray_bundle, batch
+    
+    def to(self, device: Union[torch.device, str]) -> "ZipNerfDataManager":
+        """Moves relevant data to specified device."""
+        self.device = device
+        if hasattr(self, 'train_ray_generator'):
+            self.train_ray_generator.to(device)
+        if hasattr(self, 'eval_ray_generator'):
+            self.eval_ray_generator.to(device)
+        return self


### PR DESCRIPTION
Using nerfstudio, CUDA extension compilation tries to use C++17 features (such as  'if constexpr') but setup.py specified std=c++14.